### PR TITLE
Catch OSError for read-only filesystems.

### DIFF
--- a/pyidm/setting.py
+++ b/pyidm/setting.py
@@ -57,7 +57,7 @@ def locate_setting_folder():
         os.unlink(os.path.join(folder, 'test'))
         return config.current_directory
 
-    except PermissionError:
+    except (PermissionError, OSError):
         log("No enough permission to store setting at local folder:", folder)
         log('Global setting folder will be selected:', config.global_sett_folder)
 


### PR DESCRIPTION
When pyidm is installed in a read-only filesystem (such as a nix store),
an attempt to write in the package directory will raise an OSError
rather than a PermissionError.